### PR TITLE
Update stable version of Win32 Installer

### DIFF
--- a/vim/vim-win32-installer/stable/x64.html
+++ b/vim/vim-win32-installer/stable/x64.html
@@ -1,6 +1,6 @@
 ---
 title: Stable Vim official binary for Windows x64
 redirect_to:
-  - https://github.com/vim/vim-win32-installer/releases/download/v7.4.1558/gvim_7.4.1558_x64.zip
+  - https://github.com/vim/vim-win32-installer/releases/download/v8.0.0586/gvim_8.0.0586_x64.zip
 layout: redirect
 ---

--- a/vim/vim-win32-installer/stable/x86.html
+++ b/vim/vim-win32-installer/stable/x86.html
@@ -1,6 +1,6 @@
 ---
 title: Stable Vim official binary for Windows x86
 redirect_to:
-  - https://github.com/vim/vim-win32-installer/releases/download/v7.4.1558/gvim_7.4.1558_x86.zip
+  - https://github.com/vim/vim-win32-installer/releases/download/v8.0.0586/gvim_8.0.0586_x86.zip
 layout: redirect
 ---


### PR DESCRIPTION
Currently, we can download 8.0.0586 from official web site.
https://vim.sourceforge.io/download.php#pc (A link `gvim80.exe`)
So we follow it.