### PR TITLE
Add hash to redirected page

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -7,4 +7,9 @@
 <meta http-equiv="refresh" content="0; url={{ page.redirect_to[0] }}">
 <h1>Redirecting…</h1>
 <a href="{{ page.redirect_to[0] }}">Click here if you are not redirected.</a>
+<ul>
+{% if page.hash.sha1 %}
+<li>SHA1: {{ page.hash.sha1 }}</li>
+{% endif %}
+</ul>
 <script>location="{{ page.redirect_to[0] }}"</script>


### PR DESCRIPTION
Fixes #8

#8 を実装してみました。
以下３点について相談させてください。

1. 一度にアクセスしないよう時間をバラけさせるか、もしくはダウンロードキューに入れて最大接続数を制限とかした方がいいかもしれませんが、実装はしてません。実装した方が良いでしょうか？
1. とりあえずよく見る SHA1 を表示するようにしましたが、MD5, SHA256 等のがいい、もしくは他に追加した方が良いものはあるでしょうか？
1. `_data/redirects.yml` に `github_release` が書かれてない過去や安定版のリリースについては手動で調べて追記する必要があります。
    * とりあえず全体的にこの PR の方針で良いか相談後に OK だったら追加します。

ちなみにスクリプトを実行 + `jekyll serve` 後はこんな感じになります。


### スクリーンショット

![default](https://user-images.githubusercontent.com/48169/42129711-e8393918-7d07-11e8-9fd6-5f3b5208eb1c.PNG)

### 実行後の差分

```diff
diff --git a/koron/vim-kaoriya/latest/win32.html b/koron/vim-kaoriya/latest/win32.html
index a13198d..520f345 100644
--- a/koron/vim-kaoriya/latest/win32.html
+++ b/koron/vim-kaoriya/latest/win32.html
@@ -2,5 +2,7 @@
 title: Latest Vim +kaoriya binary for Windows 32bit
 redirect_to:
   - https://github.com/koron/vim-kaoriya/releases/download/v8.1.0005-20180520/vim81-kaoriya-win32-8.1.0005-20180520.zip
+hash:
+  sha1: 9f44f8bb9867024b5ac0250602b89d7181cd95e1
 layout: redirect
 ---
diff --git a/koron/vim-kaoriya/latest/win64.html b/koron/vim-kaoriya/latest/win64.html
index 1965722..c19a3d2 100644
--- a/koron/vim-kaoriya/latest/win64.html
+++ b/koron/vim-kaoriya/latest/win64.html
@@ -2,5 +2,7 @@
 title: Latest Vim +kaoriya binary for Windows 64bit
 redirect_to:
   - https://github.com/koron/vim-kaoriya/releases/download/v8.1.0005-20180520/vim81-kaoriya-win64-8.1.0005-20180520.zip
+hash:
+  sha1: cf891e14beec3d258b4ac6b776e1b5436b716206
 layout: redirect
 ---
diff --git a/splhack/macvim-kaoriya/latest.html b/splhack/macvim-kaoriya/latest.html
index b34d686..079e1be 100644
--- a/splhack/macvim-kaoriya/latest.html
+++ b/splhack/macvim-kaoriya/latest.html
@@ -2,5 +2,7 @@
 title: Latest MacVim +kaoriya binary for MacOSX
 redirect_to:
   - https://github.com/splhack/macvim-kaoriya/releases/download/20180324/MacVim-KaoriYa-20180324.dmg
+hash:
+  sha1: 7545971b597b73b5258a8d1df0428715024a7afc
 layout: redirect
 ---
diff --git a/vim/vim-win32-installer/latest/x64.html b/vim/vim-win32-installer/latest/x64.html
index 3f77676..be1a377 100644
--- a/vim/vim-win32-installer/latest/x64.html
+++ b/vim/vim-win32-installer/latest/x64.html
@@ -2,5 +2,7 @@
 title: Latest Vim official binary for Windows x64
 redirect_to:
   - https://github.com/vim/vim-win32-installer/releases/download/v8.1.0127/gvim_8.1.0127_x64.zip
+hash:
+  sha1: 8271276f2fd9d8746b45482433902d5ee0053367
 layout: redirect
 ---
diff --git a/vim/vim-win32-installer/latest/x86.html b/vim/vim-win32-installer/latest/x86.html
index 0a66435..9839e42 100644
--- a/vim/vim-win32-installer/latest/x86.html
+++ b/vim/vim-win32-installer/latest/x86.html
@@ -2,5 +2,7 @@
 title: Latest Vim official binary for Windows x86
 redirect_to:
   - https://github.com/vim/vim-win32-installer/releases/download/v8.1.0127/gvim_8.1.0127_x86.zip
+hash:
+  sha1: a1ce478fbf63f7f3c97322adb993b5ade199d790
 layout: redirect
 ---
```